### PR TITLE
WeakAuras "Hide Timer Text"

### DIFF
--- a/cooldown.lua
+++ b/cooldown.lua
@@ -11,6 +11,10 @@ local Cooldown = {}
 
 -- queries
 function Cooldown:CanShow()
+    if self.noCooldownCount then
+        return false
+    end
+    
     local start, duration = self._tcc_start, self._tcc_duration
 
     -- no active cooldown
@@ -222,7 +226,7 @@ function Cooldown:SetNoCooldownCount(disable, owner)
     if disable then
         if not self.noCooldownCount then
             self.noCooldownCount = owner
-            Cooldown.HideText(self)
+            Cooldown.Refresh(self, true)
         end
     elseif self.noCooldownCount == owner then
         self.noCooldownCount = nil

--- a/tullaCC.toc
+++ b/tullaCC.toc
@@ -1,4 +1,4 @@
-## Interface: 90105
+## Interface: 100000
 ## Interface-BCC: 20502
 ## Interface-Classic: 11401
 ## Title: tullaCC


### PR DESCRIPTION
It is currently not possible to hide the timer text in WeakAuras, I would like to add this feature.
Since there is support for omniCC in WA, by analogy this can be done for tullaCC 
`tullaCC.Cooldown.SetNoCooldownCount(cooldown, cooldownTextDisabled)`
But without the fix  text timer continues to stay with preview and because of this, the text timer is shown wrong duration
I created a pull request for fix this and also updated toc for shadowlands 10.0

Tested:
![tL7a2XiKiO](https://user-images.githubusercontent.com/19764573/200684003-4c064a87-ef76-409a-9f07-114734db84f3.gif)
